### PR TITLE
Drop the unneeded ap01s from the metrics domain

### DIFF
--- a/basics/02-Vis-Basics/02-Vis-Basics.Rmd
+++ b/basics/02-Vis-Basics/02-Vis-Basics.Rmd
@@ -24,7 +24,7 @@ tutorial_options(exercise.timelimit = 60, exercise.checker = checker)
 library(curl)
 library(later)
 tryCatch(
-  source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE), 
+  source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE), 
   error = function(e){ 
     print("Warning: An error occurred with the tracking code.")
   }

--- a/basics/04-Programming-Basics/04-Programming-Basics.Rmd
+++ b/basics/04-Programming-Basics/04-Programming-Basics.Rmd
@@ -23,7 +23,7 @@ tutorial_options(exercise.timelimit = 60, exercise.checker = checker)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome 

--- a/iterate/introduction-to-iteration/introduction-to-iteration.Rmd
+++ b/iterate/introduction-to-iteration/introduction-to-iteration.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Iteration

--- a/iterate/list-columns/list-columns.Rmd
+++ b/iterate/list-columns/list-columns.Rmd
@@ -44,7 +44,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Motivation

--- a/iterate/map-shortcuts/map-shortcuts.Rmd
+++ b/iterate/map-shortcuts/map-shortcuts.Rmd
@@ -37,7 +37,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Why More?

--- a/iterate/map/map.Rmd
+++ b/iterate/map/map.Rmd
@@ -34,7 +34,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Map

--- a/iterate/multiple-vectors/multiple-vectors.Rmd
+++ b/iterate/multiple-vectors/multiple-vectors.Rmd
@@ -38,7 +38,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Introduction

--- a/tidy-data/01-Reshape-Data/01-Reshape-Data.Rmd
+++ b/tidy-data/01-Reshape-Data/01-Reshape-Data.Rmd
@@ -50,7 +50,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/tidy-data/02-separate-columns/02-separate-columns.Rmd
+++ b/tidy-data/02-separate-columns/02-separate-columns.Rmd
@@ -48,7 +48,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/tidy-data/03-join-datasets/03-join-datasets.Rmd
+++ b/tidy-data/03-join-datasets/03-join-datasets.Rmd
@@ -78,7 +78,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/transform-data/01-tibbles/01-tibbles.Rmd
+++ b/transform-data/01-tibbles/01-tibbles.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/transform-data/02-isolating/02-isolating.Rmd
+++ b/transform-data/02-isolating/02-isolating.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/transform-data/03-deriving/03-deriving.Rmd
+++ b/transform-data/03-deriving/03-deriving.Rmd
@@ -44,7 +44,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/01-Exploratory-Data-Analysis/01-Exploratory-Data-Analysis.Rmd
+++ b/visualize-data/01-Exploratory-Data-Analysis/01-Exploratory-Data-Analysis.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/01-bar-charts/01-bar-charts.Rmd
+++ b/visualize-data/01-bar-charts/01-bar-charts.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/03-histograms/03-histograms.Rmd
+++ b/visualize-data/03-histograms/03-histograms.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/04-boxplots/04-boxplots.Rmd
+++ b/visualize-data/04-boxplots/04-boxplots.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/05-scatterplots/05-scatterplots.Rmd
+++ b/visualize-data/05-scatterplots/05-scatterplots.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome 

--- a/visualize-data/06-line-graphs/06-line-graphs.Rmd
+++ b/visualize-data/06-line-graphs/06-line-graphs.Rmd
@@ -41,7 +41,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome 

--- a/visualize-data/07-overplotting/07-overplotting.Rmd
+++ b/visualize-data/07-overplotting/07-overplotting.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(echo = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Welcome

--- a/visualize-data/08-Customize/08-Customize.Rmd
+++ b/visualize-data/08-Customize/08-Customize.Rmd
@@ -47,7 +47,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%", message = FALSE)
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 

--- a/write-functions/advanced-control-flow/advanced-control-flow.Rmd
+++ b/write-functions/advanced-control-flow/advanced-control-flow.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## && and ||

--- a/write-functions/arguments/arguments.Rmd
+++ b/write-functions/arguments/arguments.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Matching Quiz

--- a/write-functions/control-flow/control-flow.Rmd
+++ b/write-functions/control-flow/control-flow.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## if and else

--- a/write-functions/environments/environments.Rmd
+++ b/write-functions/environments/environments.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Environments

--- a/write-functions/function-basics/function-basics.Rmd
+++ b/write-functions/function-basics/function-basics.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## Functions

--- a/write-functions/how-to-write-a-function/how-to-write-a-function.Rmd
+++ b/write-functions/how-to-write-a-function/how-to-write-a-function.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 # Capture metrics only if running an official primer hosted by RStudio
 library(curl)
 library(later)
-source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE)
+source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE)
 ```
 
 ## When to write a function

--- a/write-functions/loops/loops.Rmd
+++ b/write-functions/loops/loops.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(error = TRUE, out.width = "100%")
 library(curl)
 library(later)
 tryCatch(
-  source("https://metrics.ap01.rstudioprimers.com/learnr/installMetrics", local=TRUE), 
+  source("https://metrics.rstudioprimers.com/learnr/installMetrics", local=TRUE), 
   error = function(e){ 
     warning("An error occurred with the tracking code.")
     print(e)


### PR DESCRIPTION
I did this in RStudio so it also clipped a couple of end-of-file newlines which looks harmless to me, but let me know if you see something I missed!