### PR TITLE
Exploring addition of vocabulary terms to metadata and lessons.

### DIFF
--- a/basics/02-Vis-Basics/02-Vis-Basics.Rmd
+++ b/basics/02-Vis-Basics/02-Vis-Basics.Rmd
@@ -8,6 +8,17 @@ runtime: shiny_prerendered
 tutorial:
   id: "com.rstudio.primers.02-vis-basics"
   version: 1.0
+params:
+  assumes:
+  - value
+  - variable
+  defines:
+  - package
+  - template
+  - aesthetics
+  - geom
+  - data space
+  - visual space
 ---
 
 ```{r setup, include=FALSE}
@@ -49,7 +60,15 @@ The tutorial focuses on three basic skills:
 1. How to add variables to a graph with **aesthetics**
 1. How to make different "types" of graphs with **geoms** 
 
-In this tutorial, we will use the [core tidyverse packages](http://tidyverse.org/), including `ggplot2`. I've already loaded the packages for you, so let's begin! 
+In this tutorial, we will use the [core tidyverse packages](http://tidyverse.org/), including `ggplot2`. I've already loaded the packages for you, so let's begin!
+
+```{r glossary, echo=FALSE}
+# If we decide to include assumed and defined terms, the four lines below would be put in a function.
+assumes <- paste(params$assumes, collapse = ", ")
+defines <- paste(params$defines, collapse = ", ")
+glossary <- paste(c('**Terms**', '', '- **Assumes:**', assumes, '- **Defines:**', defines, ''), collapse = "\n")
+knitr::asis_output(glossary)
+```
 
 ***
 


### PR DESCRIPTION
1.  Add `params` key to lesson YAML header with subkeys `assumes` and `defines`, each of which stores a list of words. The former is the terms required to understand the lesson; the latter is the terms defined by the lesson.

2.  Demonstrate where/how to interpolate these into lesson text. (If we adopt this approach, the four lines would be reduced to a function, and could turn definitions into hyperlinks to a glossary shared between lessons.)

Thanks to @malcolmbarrett for introducing me to `knitr::asis_output`.