### PR TITLE
CI: Build library of renv packages

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM rstudio/r-base:3.6-bionic
+
+RUN R -e "install.packages('renv', repos='https://demo.rstudiopm.com/all/__linux__/bionic/latest')"
+RUN apt-get update --fix-missing && apt-get install -yq libssl-dev libpng-dev libnetcdf-dev libxml2-dev awscli && \
+  mkdir -p /rlibrary && \
+  chmod a+rx /rlibrary
+
+ENV R_LIBS=/rlibrary
+
+# RUN R -e 'renv::restore(library="/rlibrary")'

--- a/Jenkinsfile.library
+++ b/Jenkinsfile.library
@@ -1,0 +1,48 @@
+#!groovy
+
+//doUpload = (env.BRANCH_NAME == 'master')
+doUpload = true
+
+ansiColor('xterm') {
+  node('docker') {
+      stage('setup') {
+        if (env.BRANCH_NAME ==~ /.*\/.*/) {
+          error("Branch names must not contain slashes.")
+        }
+        checkout scm
+      }
+      
+      def image = docker.build('primers-library:latest', "-f Dockerfile.build .")
+
+      stage('Build Library') {
+        image.inside() {
+          sh "mkdir -p rlibrary/"
+          sh "mkdir -p renv-cache/"
+          sh "RENV_PATHS_ROOT=renv-cache/ R -e 'renv::restore(library=\"rlibrary/\", repos=c(CRAN=\"https://packagemanager.rstudio.com/cran/__linux__/bionic/latest\"))'"
+          sh "tar -zcvf bionic-r3-6-3.tar.gz rlibrary"
+          stash includes: 'bionic-r3-6-3.tar.gz', name: 'rlibrary'
+        }
+        print "Finished building"
+      }
+
+      stage('Upload') {
+        if (doUpload) {
+          image.inside() {
+            unstash 'rlibrary'
+            withCredentials([string(credentialsId: 'primers-role-name', variable: 'PRIMERS_ROLE_NAME')]) {
+              withCredentials([string(credentialsId: 'primers-role-account', variable: 'PRIMERS_ROLE_ACCOUNT')]) {
+                withAWS(role: PRIMERS_ROLE_NAME, roleAccount: PRIMERS_ROLE_ACCOUNT) {
+                  sh "aws s3 cp bionic-r3-6-3.tar.gz s3://primers-library/"
+                }
+              }
+            }
+          }
+        } else {
+          print "Skipping"
+        }
+      }
+      stage('Finish') {
+        print "Finished pipeline"
+      }
+  }
+}

--- a/Jenkinsfile.library
+++ b/Jenkinsfile.library
@@ -1,7 +1,6 @@
 #!groovy
 
-//doUpload = (env.BRANCH_NAME == 'master')
-doUpload = true
+doUpload = (env.BRANCH_NAME == 'master')
 
 ansiColor('xterm') {
   node('docker') {


### PR DESCRIPTION
This change automatically builds the renv library for each primers commit and uploads it to S3 at: https://librarybuilds.rstudioprimers.com/r3.6.3/bionic/$LIBRARY_HASH.tar.gz

This will allow downstream consumers to just pull in the pre-built packages rather than having to restore the library themselves.